### PR TITLE
Fix executable name of 13-ttb-parallel-sort project

### DIFF
--- a/13-tbb-parallel-sort/13-tbb-parallel-sort.pro
+++ b/13-tbb-parallel-sort/13-tbb-parallel-sort.pro
@@ -8,7 +8,7 @@ QT       += core
 
 QT       -= gui
 
-TARGET = 12-tbb-parallel-sort
+TARGET = 13-tbb-parallel-sort
 CONFIG   += console
 CONFIG   -= app_bundle
 CONFIG += c++11


### PR DESCRIPTION
minor fix: Executable name was 12* and not 13* in project 13-ttb-parallel-sort